### PR TITLE
Do not build downloaded module

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,4 +11,4 @@ fi
 export GO111MODULE=on
 export GOPROXY="$INPUT_GOPROXY"
 
-go get "$PACKAGE@$VERSION"
+go get -d "$PACKAGE@$VERSION"


### PR DESCRIPTION
Whenever a module contains only source files behind a build tag, `go get` will return an error unless the appropriate flag is passed. Since we are only aiming to trigger the proxy pull here, there is no need to build modules, hence the `-d` flag.