### PR TITLE
Tags only support on.push/on.pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ To renew the documentation on [pkg.go.dev](https://pkg.go.dev) reate a new workf
 
 ```yaml
 on:
-  release:
-    types:
-      - created
+  push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - '**/v[0-9]+.[0-9]+.[0-9]+'


### PR DESCRIPTION
Changing release to push and removed types, it finally fired up correctly when releasing a new tag.

And my module got updated on pkg.go.dev