### PR TITLE
feat(major versions): support major versions greater than 1

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,12 @@ if [[ "$VERSION" != "$TAG" ]]; then
   PACKAGE=github.com/${GITHUB_REPOSITORY}/${TAG%"/$VERSION"}
 fi
 
+# if version > 1, then add the version scope
+readonly MAJOR_VERSION="$(printf '%s' "$VERSION" | cut -d '.' -f 1 | sed 's/v//g')"
+if [ $((10#${MAJOR_VERSION})) -gt 1 ]; then
+  PACKAGE="$PACKAGE/v$MAJOR_VERSION"
+fi
+
 export GO111MODULE=on
 export GOPROXY="$INPUT_GOPROXY"
 


### PR DESCRIPTION
Ran into this issue where my go module was at `v2.0.1` and the proxy push would not work due to the scope of the version being greater than 1.

```
go get: github.com/clok/avtool@v2.0.1: reading https://proxy.golang.org/github.com/clok/avtool/@v/v2.0.1.info: 410 Gone
	server response: not found: github.com/clok/avtool@v2.0.1: invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v2
```

This change will result in the `go get` command being:

```
go get -d github.com/clok/avtool/v2@v2.0.1
```

Successful test: https://github.com/clok/avtool/runs/2024095204?check_suite_focus=true