### PR TITLE
Initialize a new dummy module before downloading the package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:1.18-alpine
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,4 +17,5 @@ fi
 export GO111MODULE=on
 export GOPROXY="$INPUT_GOPROXY"
 
-go get -d "$PACKAGE@$VERSION"
+go mod init dummy
+go get "$PACKAGE@$VERSION"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,5 +17,7 @@ fi
 export GO111MODULE=on
 export GOPROXY="$INPUT_GOPROXY"
 
+mkdir dummy
+cd dummy
 go mod init dummy
 go get "$PACKAGE@$VERSION"


### PR DESCRIPTION
Since go1.18 the behavior of `go get` has changed to operate within module context only. In case there is no `go.mod` present in the current directory, command returns with a non-zero status, which terminates the execution and fails the action.

To address this issue we're going to init a dummy module before running `go get`, which will add the target package to the `go.mod` and download it via proxy. The change should be backward-compatible with older Go versions that have module support.

Closes #5