### PR TITLE
Support custom imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ The action accepts `gopath` parameter to specify the URL of a self-hosted or any
     goproxy: https://gocenter.io
 ```
 
+### Custom import path
+
+In case your module uses custom import path, such as `example.com/myproject`, an attempt to download it using its GitHub reporitory URL will result in an error. In this case you need to provide the import path of your package as an input:
+
+```yaml
+- name: Pull new module version
+  uses: andrewslotin/go-proxy-pull-action@v1.1.0
+  with:
+      import_path: example.com/myproject
+```
+
 Why?
 ----
 

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'URL of the proxy to be passed to `go get` as GOPROXY='
     required: false
     default: 'https://proxy.golang.org'
+  import_path:
+    description: 'Package import path. If not set, github.com/<user>/<repo> is used as a default'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,9 +3,13 @@
 readonly TAG=${GITHUB_REF#refs/tags/*}
 readonly VERSION=${TAG##*/}
 
-PACKAGE=github.com/${GITHUB_REPOSITORY}
+PACKAGE=${INPUT_IMPORT_PATH:=github.com/${GITHUB_REPOSITORY}}
+
+# submodules version tags are formatted as <submodule>/vX.Y.Z,
+# so we extract the submodule name and append it to the main module
+# import path
 if [[ "$VERSION" != "$TAG" ]]; then
-  PACKAGE=github.com/${GITHUB_REPOSITORY}/${TAG%"/$VERSION"}
+  PACKAGE=${PACKAGE}/${TAG%"/$VERSION"}
 fi
 
 # if version > 1, then add the version scope


### PR DESCRIPTION
An attempt to download Go modules with custom import paths that don't match their GitHub repository URLs results in an error, e.g.
```
module declares its path as: example.com/module
        but was required as: github.com/examplecom/module
```

To address this, a new input parameter `import_path` has been added. If set, this value takes precedence over the GitHub-provided repository URL and will be used to download the module.

See [README](https://github.com/andrewslotin/go-proxy-pull-action#custom-import-path) for more details.

Closes #7 