### PR TITLE
6 arithmetic syntax error in entrypointsh when no version tag exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine
+FROM golang:1.24-alpine
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine
+FROM golang:1.23-alpine
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2020 Andrey Slotin and contributors
+Copyright (c) 2025 Nicholas Fedor
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
-Go proxy warming action
+Go Proxy Cache Updater
 =======================
+
+Note
+-----
+
+This is a fork of `andrewslotin/go-proxy-pull-action`.
+
+Go Proxy Cache Updater Action
+-----
 
 This action ensures that a newly released version of a Go module is pulled to the specified proxy.
 
 Each time there is a new tag created in repository with a name that looks like a [semantic version](https://blog.golang.org/publishing-go-modules), the action gets triggered, pulling this version with `go get` via the
-configured proxy (https://proxy.golang.org by default).
+configured proxy (<https://proxy.golang.org> by default).
 
 The action also recognizes the tags that version submodules stored within the same repository,
 e.g. `contrib/awesomity/v1.2.3`.
@@ -29,30 +37,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Pull new module version
-      uses: andrewslotin/go-proxy-pull-action@master
+      uses: nicholas-fedor/go-proxy-pull-action@master
 ```
 
 This will trigger the action each time whenever a new release is published for a tag that looks either like `vX.Y.Z` or
 `submodule/path/vX.Y.Z`.
 
-### Custom proxy
+Custom proxy
+-----
 
-The action accepts `gopath` parameter to specify the URL of a self-hosted or any other Go proxy instead of https://proxy.golang.org. For example to make sure that [GoCenter](https://gocenter.io) has the latest version of your module provide `https://gocenter.io` as a value for `goproxy` parameter:
+The action accepts `gopath` parameter to specify the URL of a self-hosted or any other Go proxy instead of <https://proxy.golang.org>. For example to make sure that [GoCenter](https://gocenter.io) has the latest version of your module provide `https://gocenter.io` as a value for `goproxy` parameter:
 
 ```yaml
 - name: Pull new module version
-  uses: andrewslotin/go-proxy-pull-action@master
+  uses: nicholas-fedor/go-proxy-pull-action@master
   with:
     goproxy: https://gocenter.io
 ```
 
-### Custom import path
+Custom import path
+-----
 
-In case your module uses custom import path, such as `example.com/myproject`, an attempt to download it using its GitHub reporitory URL will result in an error. In this case you need to provide the import path of your package as an input:
+In case your module uses custom import path, such as `example.com/myproject`, an attempt to download it using its GitHub repository URL will result in an error. In this case you need to provide the import path of your package as an input:
 
 ```yaml
 - name: Pull new module version
-  uses: andrewslotin/go-proxy-pull-action@v1.1.0
+  uses: nicholas-fedor/go-proxy-pull-action@v1.1.0
   with:
       import_path: example.com/myproject
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'Go proxy warming'
+name: 'Go Proxy Cache Updater'
 description: 'Pull the new release of a module to the Go proxy cache'
-author: 'Andrey Slotin'
+author: 'Nicholas Fedor'
 inputs:
   goproxy:
     description: 'URL of the proxy to be passed to `go get` as GOPROXY='

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,17 +5,22 @@ readonly VERSION=${TAG##*/}
 
 PACKAGE=${INPUT_IMPORT_PATH:=github.com/${GITHUB_REPOSITORY}}
 
-# submodules version tags are formatted as <submodule>/vX.Y.Z,
+# Submodules version tags are formatted as <submodule>/vX.Y.Z,
 # so we extract the submodule name and append it to the main module
 # import path
-if [[ "$VERSION" != "$TAG" ]]; then
+if [ "$VERSION" != "$TAG" ]; then
   PACKAGE=${PACKAGE}/${TAG%"/$VERSION"}
 fi
 
-# if version > 1, then add the version scope
+# If either check fails, the version scoping logic (adding /vX to the package path) 
+# is skipped, preventing the arithmetic error
 readonly MAJOR_VERSION="$(printf '%s' "$VERSION" | cut -d '.' -f 1 | sed 's/v//g')"
-if [ $((10#${MAJOR_VERSION})) -gt 1 ]; then
-  PACKAGE="$PACKAGE/v$MAJOR_VERSION"
+# [ -n "$MAJOR_VERSION" ] check ensures MAJOR_VERSION is not empty
+# grep -q '^[0-9]\+$' check ensures MAJOR_VERSION is numeric (contains only digits)
+if [ -n "$MAJOR_VERSION" ] && echo "$MAJOR_VERSION" | grep -q '^[0-9]\+$'; then
+  if [ $((10#${MAJOR_VERSION})) -gt 1 ]; then
+    PACKAGE="$PACKAGE/v$MAJOR_VERSION"
+  fi
 fi
 
 export GO111MODULE=on

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ]
+}


### PR DESCRIPTION
Fix the entrypoint.sh script to handle cases where `VERSION `or `MAJOR_VERSION` is empty or non-numeric.
Adds validation to skip the version scoping logic if no valid version tag is present.