### PR TITLE
Update Dockerfile to Go 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine
+FROM golang:1.26-alpine
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
This is required to build projects with a minimum go 1.26 version.

```
go: creating new go.mod: module dummy
go: downloading github.com/blinklabs-io/dingo v0.42.0
go: github.com/blinklabs-io/dingo@v0.42.0 requires go >= 1.26.0 (running go 1.25.10; GOTOOLCHAIN=local)
```